### PR TITLE
Calculate a hash for each parsed IPDL file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -190,6 +191,11 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "sha1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a21935ce5a4dfa48e3ded1aefbbe353fb9ab258b0d3fa0bd168bef00797b3dc7"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)" = "bff9fc1c79f2dec76b253273d07682e94a978bd8f132ded071188122b2af9818"
+"checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "50c069df92e4b01425a8bf3576d5d417943a6a7272fbabaf5bd80b1aaa76442e"
 "checksum term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3deff8a2b3b6607d6d7cc32ac25c0b33709453ca9cceac006caac51e963cf94a"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ lalrpop = "0.12.1"
 [dependencies]
 lalrpop-util = "0.12.1"
 getopts = "0.2.14"
+sha1 = "0.2.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -281,4 +281,5 @@ pub struct TranslationUnit {
     pub using: Vec<UsingStmt>,
     pub structs_and_unions: Vec<(Namespace, StructOrUnion)>,
     pub protocol: Option<(Namespace, Protocol)>,
+    pub hash: String,
 }

--- a/src/ipdl.lalrpop
+++ b/src/ipdl.lalrpop
@@ -83,7 +83,8 @@ pub TranslationUnit: TranslationUnit = {
             includes: includes,
             using: using,
             structs_and_unions: structs_and_unions,
-            protocol: protocol
+            protocol: protocol,
+            hash: parser_state.hash.clone(),
         }
     }
 };


### PR DESCRIPTION
Run SHA-1 on the uncommented file contents, and then stash that
in the generated TranslationUnit.

This will be useful when determining what things need to be written
to disk.